### PR TITLE
 Remove clipping for canvas. Fixes one line text trim at browsers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.2
+
+- **ADDED**: All field in `MarkdownThemeData()` are now optional.
+- **ADDED**: `MarkdownThemeData{}.headingStyleFor` method to customize heading styles.
+- **FIXED**: Remove clipping for canvas. Fixes one line text trim at browsers.
+- **FIXED**: Correctly apply styles to text in blocks.
+
 ## 0.0.1
 
 - **ADDED**: Initial release with basic functionality.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,10 +29,7 @@ class App extends StatelessWidget {
         home: const HomeScreen(),
         builder: (context, child) => MarkdownTheme(
           data: MarkdownThemeData(
-            textStyle: const TextStyle(
-              fontSize: 16.0,
-              color: Colors.black87,
-            ),
+            textStyle: const TextStyle(fontSize: 14.0, color: Colors.black),
             textDirection: TextDirection.ltr,
             textScaler: TextScaler.noScaling,
             // Exclude images from the markdown rendering,
@@ -79,7 +76,8 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void initState() {
     super.initState();
-    _outputController.value = Markdown.fromString(_inputController.text);
+    final initialMarkdown = Markdown.fromString(_inputController.text);
+    _outputController.value = initialMarkdown;
     _inputController.addListener(_onInputChanged);
   }
 
@@ -247,6 +245,8 @@ __This will be underline__
 `This is inline code`
 
 ~~This text will be strikethrough~~
+
+==This text will be highlighted==
 
 _`You` **can** __combine__ ~~them~~_
 

--- a/lib/src/markdown.dart
+++ b/lib/src/markdown.dart
@@ -55,11 +55,17 @@ final class Markdown {
       if (i > 0) buffer.writeln();
       switch (block) {
         case MD$Paragraph(:List<MD$Span> spans):
-          for (final span in spans) buffer.write(span.text);
+          for (final span in spans) {
+            buffer.write(span.text);
+          }
         case MD$Heading(:List<MD$Span> spans):
-          for (final span in spans) buffer.write(span.text);
+          for (final span in spans) {
+            buffer.write(span.text);
+          }
         case MD$Quote(:List<MD$Span> spans):
-          for (final span in spans) buffer.write(span.text);
+          for (final span in spans) {
+            buffer.write(span.text);
+          }
         case MD$Code(:String text):
           buffer.write(text);
         case MD$List(:List<MD$ListItem> items):
@@ -75,7 +81,9 @@ final class Markdown {
             for (var k = 0; k < row.cells.length; k++) {
               //if (k > 0) buffer.write(' | ');
               final spans = row.cells[k];
-              for (final span in spans) buffer.write(span.text);
+              for (final span in spans) {
+                buffer.write(span.text);
+              }
             }
           }
         case MD$Divider():

--- a/lib/src/render.dart
+++ b/lib/src/render.dart
@@ -134,15 +134,11 @@ class MarkdownRenderObject extends RenderBox {
     // ignore: unused_local_variable
     final canvas = context.canvas
       ..save()
-      ..translate(offset.dx, offset.dy)
-      ..clipRect(Rect.fromLTWH(0, 0, size.width, size.height));
+      ..translate(offset.dx, offset.dy);
+    //..clipRect(Rect.fromLTWH(0, 0, size.width, size.height));
 
     _painter.paint(canvas, size);
 
-    // Implement the painting logic here.
-    // This is where you would use the painter to draw the markdown content.
-    // For example:
-    // painter.paint(context, offset, size);
     canvas.restore();
   }
 }
@@ -618,15 +614,7 @@ class BlockPainter$Heading
           text: _paragraphFromMarkdownSpans(
             spans: spans,
             theme: theme,
-            textStyle: switch (level) {
-              1 => theme.h1Style,
-              2 => theme.h2Style,
-              3 => theme.h3Style,
-              4 => theme.h4Style,
-              5 => theme.h5Style,
-              6 => theme.h6Style,
-              _ => theme.textStyle,
-            },
+            textStyle: theme.headingStyleFor(level),
           ),
           textAlign: TextAlign.start,
           textDirection: theme.textDirection,
@@ -676,7 +664,7 @@ class BlockPainter$Quote with ParagraphGestureHandler implements BlockPainter {
           text: _paragraphFromMarkdownSpans(
             spans: spans,
             theme: theme,
-            textStyle: theme.quoteStyle,
+            textStyle: theme.quoteStyle ?? theme.textStyle,
           ),
           textAlign: TextAlign.start,
           textDirection: theme.textDirection,
@@ -741,10 +729,11 @@ class BlockPainter$Quote with ParagraphGestureHandler implements BlockPainter {
         const quoteFamily = 'MaterialIcons';
         final textStyle = TextStyle(
           fontFamily: quoteFamily,
-          fontSize: theme.textStyle.fontSize ?? 14.0,
+          fontSize:
+              theme.quoteStyle?.fontSize ?? theme.textStyle.fontSize ?? 14.0,
           color: const Color(0xFF7F7F7F), // Gray color for the quote icon.
         );
-        final painter = TextPainter(
+        final quotePainter = TextPainter(
           text: TextSpan(
             text: String.fromCharCode(quoteCodePoint),
             style: textStyle,
@@ -756,23 +745,23 @@ class BlockPainter$Quote with ParagraphGestureHandler implements BlockPainter {
         canvas
           ..save()
           ..translate(
-            _size.width + painter.width,
+            _size.width + quotePainter.width,
             offset + _size.height,
           )
           ..rotate(math.pi);
-        painter.paint(
+        quotePainter.paint(
           canvas,
           Offset(
             _size.width,
-            _size.height - painter.height,
+            _size.height - quotePainter.height,
           ),
         );
         canvas.restore();
-        painter.paint(
+        quotePainter.paint(
           canvas,
           Offset(
-            size.width - painter.width - 2.0,
-            offset + _size.height - painter.height,
+            size.width - quotePainter.width - 2.0,
+            offset + _size.height - quotePainter.height,
           ),
         );
       } on Object {

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -11,38 +11,16 @@ class MarkdownThemeData implements ThemeExtension<MarkdownThemeData> {
   /// Creates a [MarkdownThemeData] instance.
   /// {@macro markdown_theme_data}
   MarkdownThemeData({
+    required this.textStyle,
     this.textDirection = TextDirection.ltr,
     this.textScaler = TextScaler.noScaling,
-    this.textStyle = const TextStyle(fontSize: 14.0),
-    this.h1Style = const TextStyle(
-      fontSize: 24.0,
-      fontWeight: FontWeight.bold,
-      decoration: TextDecoration.underline,
-      decorationStyle: TextDecorationStyle.solid,
-    ),
-    this.h2Style = const TextStyle(
-      fontSize: 22.0,
-      fontWeight: FontWeight.bold,
-    ),
-    this.h3Style = const TextStyle(
-      fontSize: 20.0,
-      fontWeight: FontWeight.bold,
-    ),
-    this.h4Style = const TextStyle(
-      fontSize: 18.0,
-      fontWeight: FontWeight.bold,
-    ),
-    this.h5Style = const TextStyle(
-      fontSize: 16.0,
-      fontWeight: FontWeight.bold,
-    ),
-    this.h6Style = const TextStyle(
-      fontSize: 14.0,
-      fontWeight: FontWeight.bold,
-    ),
-    this.quoteStyle = const TextStyle(
-      fontSize: 14.0,
-    ),
+    this.h1Style,
+    this.h2Style,
+    this.h3Style,
+    this.h4Style,
+    this.h5Style,
+    this.h6Style,
+    this.quoteStyle,
     this.blockFilter,
     this.spanFilter,
     this.builder,
@@ -62,25 +40,25 @@ class MarkdownThemeData implements ThemeExtension<MarkdownThemeData> {
   final TextStyle textStyle;
 
   /// Default text style for headings h1.
-  final TextStyle h1Style;
+  final TextStyle? h1Style;
 
   /// Default text style for headings h2.
-  final TextStyle h2Style;
+  final TextStyle? h2Style;
 
   /// Default text style for headings h3.
-  final TextStyle h3Style;
+  final TextStyle? h3Style;
 
   /// Default text style for headings h4.
-  final TextStyle h4Style;
+  final TextStyle? h4Style;
 
   /// Default text style for headings h5.
-  final TextStyle h5Style;
+  final TextStyle? h5Style;
 
   /// Default text style for headings h6.
-  final TextStyle h6Style;
+  final TextStyle? h6Style;
 
   /// Default text style for quote blocks.
-  final TextStyle quoteStyle;
+  final TextStyle? quoteStyle;
 
   /// A filter function to determine whether a block should be rendered.
   /// If the function returns `true`, the block will be rendered.
@@ -111,35 +89,81 @@ class MarkdownThemeData implements ThemeExtension<MarkdownThemeData> {
   /// It receives the link title and URL as parameters.
   final void Function(String title, String url)? onLinkTap;
 
+  final List<TextStyle?> _headingStyles = List<TextStyle?>.filled(8, null);
+
+  /// Returns a [TextStyle] for the given heading level.
+  /// The level should be between 1 and 6, inclusive.
+  TextStyle headingStyleFor(int level) =>
+      _headingStyles[level] ??= switch (level.clamp(1, 7)) {
+        1 => h1Style ??
+            textStyle.copyWith(
+              fontSize: (textStyle.fontSize ?? 14.0) + 10.0,
+              fontWeight: FontWeight.bold,
+              decoration: TextDecoration.underline,
+              decorationStyle: TextDecorationStyle.solid,
+            ),
+        2 => h2Style ??
+            textStyle.copyWith(
+              fontSize: (textStyle.fontSize ?? 14.0) + 8.0,
+              fontWeight: FontWeight.bold,
+            ),
+        3 => h3Style ??
+            textStyle.copyWith(
+              fontSize: (textStyle.fontSize ?? 14.0) + 6.0,
+              fontWeight: FontWeight.bold,
+            ),
+        4 => h4Style ??
+            textStyle.copyWith(
+              fontSize: (textStyle.fontSize ?? 14.0) + 4.0,
+              fontWeight: FontWeight.bold,
+            ),
+        5 => h5Style ??
+            textStyle.copyWith(
+              fontSize: (textStyle.fontSize ?? 14.0) + 2.0,
+              fontWeight: FontWeight.bold,
+            ),
+        6 => h6Style ??
+            textStyle.copyWith(
+              fontSize: (textStyle.fontSize ?? 14.0) + 0.0,
+              fontWeight: FontWeight.bold,
+            ),
+        _ => textStyle,
+      };
+
   final HashMap<int, TextStyle> _textStyles;
 
   /// Returns a [TextStyle] for the given [MD$Style].
   TextStyle textStyleFor(MD$Style style) => _textStyles.putIfAbsent(
         style.hashCode,
-        () => TextStyle(
-          fontWeight:
-              style.contains(MD$Style.bold) || style.contains(MD$Style.link)
-                  ? FontWeight.bold
-                  : FontWeight.normal,
-          fontStyle: style.contains(MD$Style.italic)
-              ? FontStyle.italic
-              : FontStyle.normal,
-          decoration: style.contains(MD$Style.underline)
-              ? TextDecoration.underline
-              : style.contains(MD$Style.strikethrough)
-                  ? TextDecoration.lineThrough
-                  : TextDecoration.none,
-          fontFamily: style.contains(MD$Style.monospace)
-              ? 'monospace'
-              : textStyle.fontFamily,
-          color: style.contains(MD$Style.link)
-              ? Colors.purple
-              : style.contains(MD$Style.highlight)
-                  ? Colors.yellow
-                  : textStyle.color,
-          backgroundColor: style.contains(MD$Style.monospace)
-              ? Colors.black12
-              : textStyle.backgroundColor,
+        () => textStyle.copyWith(
+          fontWeight: switch (style) {
+            var s when s.contains(MD$Style.bold) => FontWeight.bold,
+            var s when s.contains(MD$Style.link) => FontWeight.bold,
+            var s when s.contains(MD$Style.highlight) => FontWeight.bold,
+            _ => null,
+          },
+          fontStyle: style.contains(MD$Style.italic) ? FontStyle.italic : null,
+          decoration: switch (style) {
+            var s when s.contains(MD$Style.underline) =>
+              TextDecoration.underline,
+            var s when s.contains(MD$Style.strikethrough) =>
+              TextDecoration.lineThrough,
+            _ => null,
+          },
+          fontFamily: style.contains(MD$Style.monospace) ? 'monospace' : null,
+          color: switch (style) {
+            var s when s.contains(MD$Style.link) => Colors.indigo,
+            var s when s.contains(MD$Style.highlight) => Colors.black,
+            var s when s.contains(MD$Style.monospace) => Colors.black,
+            _ => null,
+          },
+          backgroundColor: switch (style) {
+            var s when s.contains(MD$Style.highlight) =>
+              Colors.deepOrange.withValues(alpha: 0.25),
+            var s when s.contains(MD$Style.monospace) =>
+              Colors.grey.withValues(alpha: 0.25),
+            _ => null,
+          },
         ),
       );
 

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -25,7 +25,8 @@ class MarkdownThemeData implements ThemeExtension<MarkdownThemeData> {
     this.spanFilter,
     this.builder,
     this.onLinkTap,
-  }) : _textStyles = HashMap<int, TextStyle>();
+  })  : _headingStyles = List<TextStyle?>.filled(8, null),
+        _textStyles = HashMap<int, TextStyle>();
 
   @override
   Object get type => MarkdownThemeData;
@@ -89,7 +90,7 @@ class MarkdownThemeData implements ThemeExtension<MarkdownThemeData> {
   /// It receives the link title and URL as parameters.
   final void Function(String title, String url)? onLinkTap;
 
-  final List<TextStyle?> _headingStyles = List<TextStyle?>.filled(8, null);
+  final List<TextStyle?> _headingStyles;
 
   /// Returns a [TextStyle] for the given heading level.
   /// The level should be between 1 and 6, inclusive.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: >
   Markdown library written in Dart.
   It can parse and display Markdown.
 
-version: 0.0.1
+version: 0.0.2
 
 homepage: https://github.com/DoctorinaAI/md
 repository: https://github.com/DoctorinaAI/md


### PR DESCRIPTION
- **ADDED**: All field in `MarkdownThemeData()` are now optional.
- **ADDED**: `MarkdownThemeData{}.headingStyleFor` method to customize heading styles.
- **FIXED**: Remove clipping for canvas. Fixes one line text trim at browsers.
- **FIXED**: Correctly apply styles to text in blocks.