### PR TITLE
fix: escaping for special characters (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+
+- **FIXED**: Fixed escaping of special characters. [#6] 
+
 ## 0.0.5
 
 - **FIXED**: Fixed parsing url such as `[text](https://domain.com/path(with)brackets)`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: >
   Markdown library written in Dart.
   It can parse and display Markdown.
 
-version: 0.0.5
+version: 0.0.6
 
 homepage: https://github.com/DoctorinaAI/md
 repository: https://github.com/DoctorinaAI/md

--- a/test/parser/parser_test.dart
+++ b/test/parser/parser_test.dart
@@ -369,6 +369,39 @@ void main() => group('Parse', () {
           ),
         );
       });
+
+      group('Parse escaped characters', () {
+        const escapedCharacterTests = {
+          r'\\': r'\', // Backslash
+          r'\`': '`', // Backtick
+          r'\*': '*', // Asterisk
+          r'\_': '_', // Underscore
+          r'\{': '{', // Left curly brace
+          r'\}': '}', // Right curly brace
+          r'\[': '[', // Left square bracket
+          r'\]': ']', // Right square bracket
+          r'\(': '(', // Left parenthesis
+          r'\)': ')', // Right parenthesis
+          r'\#': '#', // Hash mark
+          r'\+': '+', // Plus sign
+          r'\-': '-', // Minus sign (hyphen)
+          r'\.': '.', // Period
+          r'\!': '!', // Exclamation mark
+        };
+
+        for (final entry in escapedCharacterTests.entries) {
+          test('should correctly unescape "${entry.key}"', () {
+            final markdown = markdownDecoder.convert(entry.key);
+            expect(markdown.text, entry.value);
+          });
+        }
+
+        test('should not escape non-special characters', () {
+          const input = r'\no esc\aped strin\g';
+          final markdown = markdownDecoder.convert(input);
+          expect(markdown.text, input);
+        });
+      });
     });
 
 const String _testSample = r'''


### PR DESCRIPTION
The main issue was that characters after \ were added to Uint8List, but any characters can follow the backslash, not only special ones. This broke the encoding.

Also added escaping only for the required characters.